### PR TITLE
Add `theme_path_prefix` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ js_include:
 # The global title that is displayed at the top of the pages
 global_title: Styleguide
 
+# The prefix path for theme's assets
+theme_path_prefix: 'styleguides'
+
 ```
 
 In this example the markdown file `app/styles/styleguide.md` is used for the content on the index page. Also, if you're using Bower, adjust the package path accordingly: ```documentation_assets: bower_components/hologram-github-theme```.

--- a/_footer.html
+++ b/_footer.html
@@ -8,10 +8,10 @@
   </div>
 
   <script src="https://code.jquery.com/jquery-1.11.2.min.js"></script>
-  <script src="scripts/vendor/jquery.waypoints.min.js"></script>
-  <script src="scripts/vendor/sticky.min.js"></script>
-  <script src="scripts/vendor/infinite.min.js"></script>
-  <script src="scripts/hgt.js"></script>
+  <script src="<%= @config['theme_path_prefix'] %>/scripts/vendor/jquery.waypoints.min.js"></script>
+  <script src="<%= @config['theme_path_prefix'] %>/scripts/vendor/sticky.min.js"></script>
+  <script src="<%= @config['theme_path_prefix'] %>/scripts/vendor/infinite.min.js"></script>
+  <script src="<%= @config['theme_path_prefix'] %>/scripts/hgt.js"></script>
 
   <% if @config['js_include'].to_s.strip.length != 0 %>
     <% @config['js_include'].each do |js| %>

--- a/_header.html
+++ b/_header.html
@@ -6,8 +6,8 @@
     <title><%= title %> <% if title != '' %>&ndash;<% end %> <%= @config['global_title'] %></title>
 
     <!-- Styleguide CSS -->
-    <link rel="stylesheet" href="styles/hgt-syntax.css">
-    <link rel="stylesheet" href="styles/hgt.css">
+    <link rel="stylesheet" href="<%= @config['theme_path_prefix'] %>/styles/hgt-syntax.css">
+    <link rel="stylesheet" href="<%= @config['theme_path_prefix'] %>/styles/hgt.css">
 
     <!-- Source CSS -->
     <% if @config['css_include'].to_s.strip.length != 0 %>


### PR DESCRIPTION
Hello.

I'm using with Rails project.

I put compiled files to `example.com/styleguides/` as destination .

<img width="316" alt="styleguide_ _styleguide_ _1__bash" src="https://cloud.githubusercontent.com/assets/2703486/13025441/ee514486-d24a-11e5-9014-d5e51e0acfa1.png">

but, this theme's resouce path is fixed. (header footer).

I want to setting relative path to theme's assets.

Cloud you please check my PR?
thanks.
